### PR TITLE
Remove Brotli header

### DIFF
--- a/douban/people.py
+++ b/douban/people.py
@@ -26,7 +26,7 @@ class People:
     def __album(self, start):
         headers = {
             'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8',
-            'Accept-Encoding': 'gzip, deflate, br',
+            'Accept-Encoding': 'gzip, deflate',
             'Accept-Language': 'zh-CN,zh;q=0.8,en-US;q=0.6,en;q=0.4',
             'Connection': 'keep-alive',
             'DNT': '1',


### PR DESCRIPTION
Python的`Requests`模块目前无法自动解压缩`Brotli`，如果`header`里有`br`，豆瓣服务器目前会优先返回`Brotli`压缩后的内容，从而导致"下载个人所有相册"功能失败。
请考虑删除这里的`br`。或者如果一定要保留`br`，那么可以安装`brotlipy`，然后加上以下代码：
```Python
import brotli

key = 'Content-Encoding'
if(key in r.headers and r.headers['Content-Encoding'] == 'br'):
    data = brotli.decompress(r.content)
    data_decoded = data.decode('utf-8')
    album_urls = re.findall(r'https?://www.douban.com/photos/album/(\d+)', data_decoded)
    return set(album_urls)
```