### PR TITLE
Fix pip install README UnicodeDecodeError

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ requirements = [
 
 def long_desc():
     try:
-        with open('README.md') as f:
+        with open('README.md', encoding='utf8') as f:
             return f.read()
     except IOError:
         return ''


### PR DESCRIPTION
On Windows, Python 3.7 : "UnicodeDecodeError: 'gbk' codec can't decode byte"